### PR TITLE
always record new datapoints, even if they haven't changed value

### DIFF
--- a/custom_components/solis/sensor.py
+++ b/custom_components/solis/sensor.py
@@ -176,7 +176,7 @@ class SolisSensor(ServiceSubscriber, SensorEntity):
 
     def do_update(self, value: Any, last_updated: datetime) -> bool:
         """ Update the sensor."""
-        if self.hass and self._attr_native_value != value:
+        if self.hass:
             self._attr_native_value = value
             self._attributes[LAST_UPDATED] = last_updated
             self.async_write_ha_state()


### PR DESCRIPTION
I noticed that I was missing some large chunks of data overnight on some graphs -- on investigating, it appears that if the data value hasn't changed, the sensor's value isn't recorded.  (Since I use Graphite downstream from my Home Assistant to display graphs, it highlights missing data like this, whereas HA's own graphs are more lenient.)  I also think it's useful to record the datapoints if we were successfully able to measure them, to differentiate from cases where the datapoint was unmeasureable due to a bug or other issue (which unfortunately tends to happen to me a fair bit due to wifi issues).