### PR TITLE
Revert "correct_daily_on_grid_energy_enabled" workaround

### DIFF
--- a/custom_components/solis/workarounds.yaml
+++ b/custom_components/solis/workarounds.yaml
@@ -1,4 +1,4 @@
 # Switch on/off SolisCloud workarounds 
 
 #SolisCloud returns daily on grid energy a factor 10 off
-correct_daily_on_grid_energy_enabled: true
+correct_daily_on_grid_energy_enabled: false


### PR DESCRIPTION
Turn off this workaround, it appears to be no longer necessary (for me at least).  Can anyone else confirm this?

Forked off from https://github.com/hultenvp/solis-sensor/pull/227/files#r1046410150